### PR TITLE
Bugfix: cannot set 'mode' with DI configuration.

### DIFF
--- a/src/Form/Type/AceType.php
+++ b/src/Form/Type/AceType.php
@@ -229,15 +229,15 @@ class AceType extends AbstractType
                 return $value;
             })
             ->setNormalizer('mode', function (Options $options, $value) {
-                if (null !== $value && false === strpos($value, '/')) {
-                    $value = 'ace/mode/' . $value;
-                }
-
-                return $value;
+                return $this->normalizeMode($value);
             })
             ->setNormalizer('config', function (Options $options, $value) {
-                if (empty($value['mode'])) {
-                    $value['mode'] = $options['mode'];
+                $optionsMode = $this->normalizeMode($options['mode']);
+
+                if (!empty($value['mode'])) {
+                    $value['mode'] = $this->normalizeMode($value['mode']);
+                } elseif ($optionsMode !== null) {
+                    $value['mode'] = $optionsMode;
                 }
 
                 return $value;
@@ -266,5 +266,19 @@ class AceType extends AbstractType
     public function getBlockPrefix()
     {
         return 'ace';
+    }
+
+    /**
+     * @param string $mode
+     *
+     * @return string
+     */
+    protected function normalizeMode($mode)
+    {
+        if (null !== $mode && false === strpos($mode, '/')) {
+            $mode = 'ace/mode/' . $mode;
+        }
+
+        return $mode;
     }
 }

--- a/src/Form/Type/AceType.php
+++ b/src/Form/Type/AceType.php
@@ -173,6 +173,9 @@ class AceType extends AbstractType
             'maxLines' => 100,
         ], $config);
 
+        $config['mode']  = $this->normalizeMode($config['mode'] ?? null);
+        $config['theme'] = $this->normalizeTheme($config['theme'] ?? null);
+
         $builder->setAttribute('config', $config);
     }
 
@@ -271,7 +274,7 @@ class AceType extends AbstractType
     /**
      * @param string $mode
      *
-     * @return string
+     * @return string|null
      */
     protected function normalizeMode($mode)
     {
@@ -280,5 +283,19 @@ class AceType extends AbstractType
         }
 
         return $mode;
+    }
+
+    /**
+     * @param string $theme
+     *
+     * @return string|null
+     */
+    protected function normalizeTheme($theme)
+    {
+        if (null !== $theme && false === strpos($theme, '/')) {
+            $theme = 'ace/theme/' . $theme;
+        }
+
+        return $theme;
     }
 }


### PR DESCRIPTION
With this bugfix you can set the `mode` with any of these configurations:

```yaml
phpmob_ace:
    configs:
        html:
            autoScrollEditorIntoView: true
            maxLines: 20
            minLines: 5
            mode: 'ace/mode/html'
            theme: 'ace/theme/github'
```

```php
public function buildForm(FormBuilderInterface $builder, array $options)
{
    $builder
        ->add('html', AceType::class, [
            'required'    => false,
            'mode' => 'html',
        ]);
}
```

```php
public function buildForm(FormBuilderInterface $builder, array $options)
{
    $builder
        ->add('html', AceType::class, [
            'required'    => false,
            'config' => [
                'mode' => 'html'
            ]
        ]);
}
```

When combining these methods, the first one has less priority than the last one.

Fixes #1 